### PR TITLE
KAROO-12695: Add support for dev field array values

### DIFF
--- a/developer_field.go
+++ b/developer_field.go
@@ -1,5 +1,7 @@
 package fit
 
+import "reflect"
+
 // DeveloperField holds the value of a developer field and associated metadata to allow for dynamic parsing.
 type DeveloperField struct {
 	DeveloperDataIndex    uint8
@@ -7,5 +9,37 @@ type DeveloperField struct {
 	BaseTypeId            FitBaseType
 	FieldName             string
 	Units                 string
-	Value                 interface{}
+	value                 interface{}
+}
+
+func (f *DeveloperField) Value() interface{} {
+	v := reflect.ValueOf(f.value)
+	switch v.Type().Kind() {
+	case reflect.Slice, reflect.Array:
+		return v.Index(0).Interface()
+	default:
+		return f.value
+	}
+}
+
+func (f *DeveloperField) Values() []interface{} {
+	if f.value == nil {
+		return nil
+	}
+
+	v := reflect.ValueOf(f.value)
+	switch v.Type().Kind() {
+	case reflect.Slice, reflect.Array:
+		values, ok := (f.value).([]interface{})
+		if ok {
+			return values
+		}
+
+		for i := 0; i < v.Len(); i++ {
+			values = append(values, v.Index(i))
+		}
+		return values
+	default:
+		return []interface{}{f.value}
+	}
 }

--- a/developer_field.go
+++ b/developer_field.go
@@ -35,7 +35,7 @@ func getUint64(v reflect.Value) uint64 {
 		reflect.Uint64:
 		return v.Uint()
 	default:
-		return 0xFFFFFFFFFFFFFFFF
+		return math.MaxUint64
 	}
 }
 
@@ -68,7 +68,7 @@ func (f *DeveloperField) Uint64Slice() []uint64 {
 		}
 	default:
 		v := getUint64(f.value)
-		if v != 0xFFFFFFFFFFFFFFFF {
+		if v != math.MaxUint64 {
 			values = append(values, v)
 		}
 	}

--- a/developer_field.go
+++ b/developer_field.go
@@ -1,6 +1,9 @@
 package fit
 
-import "reflect"
+import (
+	"math"
+	"reflect"
+)
 
 // DeveloperField holds the value of a developer field and associated metadata to allow for dynamic parsing.
 type DeveloperField struct {
@@ -9,37 +12,66 @@ type DeveloperField struct {
 	BaseTypeId            FitBaseType
 	FieldName             string
 	Units                 string
-	value                 interface{}
+	value                 reflect.Value
 }
 
-func (f *DeveloperField) Value() interface{} {
-	v := reflect.ValueOf(f.value)
-	switch v.Type().Kind() {
-	case reflect.Slice, reflect.Array:
-		return v.Index(0).Interface()
+func first(v reflect.Value) reflect.Value {
+	switch v.Kind() {
+	case reflect.Slice,
+		reflect.Array:
+		if v.Len() > 0 {
+			return v.Index(0)
+		}
+	}
+	return v
+}
+
+func getUint64(v reflect.Value) uint64 {
+	switch v.Kind() {
+	case reflect.Uint,
+		reflect.Uint8,
+		reflect.Uint16,
+		reflect.Uint32,
+		reflect.Uint64:
+		return v.Uint()
 	default:
-		return f.value
+		return 0xFFFFFFFFFFFFFFFF
 	}
 }
 
-func (f *DeveloperField) Values() []interface{} {
-	if f.value == nil {
-		return nil
-	}
-
-	v := reflect.ValueOf(f.value)
-	switch v.Type().Kind() {
-	case reflect.Slice, reflect.Array:
-		values, ok := (f.value).([]interface{})
-		if ok {
-			return values
-		}
-
-		for i := 0; i < v.Len(); i++ {
-			values = append(values, v.Index(i))
-		}
-		return values
+func getFloat64(v reflect.Value) float64 {
+	switch v.Kind() {
+	case reflect.Float32,
+		reflect.Float64:
+		return v.Float()
 	default:
-		return []interface{}{f.value}
+		return math.NaN()
 	}
+}
+
+func (f *DeveloperField) Uint64() uint64 {
+	return getUint64(first(f.value))
+}
+
+func (f *DeveloperField) Float64() float64 {
+	return getFloat64(first(f.value))
+}
+
+func (f *DeveloperField) Uint64Slice() []uint64 {
+	var values []uint64
+
+	switch f.value.Kind() {
+	case reflect.Slice:
+		for i := 0; i < f.value.Len(); i++ {
+			v := getUint64(f.value.Index(i))
+			values = append(values, v)
+		}
+	default:
+		v := getUint64(f.value)
+		if v != 0xFFFFFFFFFFFFFFFF {
+			values = append(values, v)
+		}
+	}
+
+	return values
 }

--- a/reader.go
+++ b/reader.go
@@ -753,7 +753,7 @@ func (d *decoder) parseDataFields(dm *defmsg, knownMsg bool, msgv reflect.Value)
 			BaseTypeId:            fieldDesc.FitBaseTypeId,
 			FieldName:             fieldName,
 			Units:                 units,
-			Value:                 value,
+			value:                 value,
 		}
 		devFieldsMap := msgv.FieldByName("DeveloperFields")
 		devFieldsMap.SetMapIndex(reflect.ValueOf(fieldName), reflect.ValueOf(devField))
@@ -776,45 +776,69 @@ func (d *decoder) parseDataFields(dm *defmsg, knownMsg bool, msgv reflect.Value)
 	return msgv, nil
 }
 
+func parseFieldData(baseType FitBaseType, bytes []byte, arch binary.ByteOrder) (interface{}, error) {
+	switch baseType {
+	case FitBaseTypeByte, FitBaseTypeEnum, FitBaseTypeUint8, FitBaseTypeUint8z:
+		return uint64(bytes[0]), nil
+	case FitBaseTypeSint8:
+		return int64(bytes[0]), nil
+	case FitBaseTypeSint16:
+		return int64(arch.Uint16(bytes)), nil
+	case FitBaseTypeUint16, FitBaseTypeUint16z:
+		return uint64(arch.Uint16(bytes)), nil
+	case FitBaseTypeSint32:
+		return int64(arch.Uint32(bytes)), nil
+	case FitBaseTypeUint32, FitBaseTypeUint32z:
+		return uint64(arch.Uint32(bytes)), nil
+	case FitBaseTypeFloat32:
+		bits := arch.Uint32(bytes)
+		return float64(math.Float32frombits(bits)), nil
+	case FitBaseTypeFloat64:
+		bits := arch.Uint64(bytes)
+		return math.Float64frombits(bits), nil
+	case FitBaseTypeString:
+		return parseFieldString(bytes), nil
+	}
+	return nil, fmt.Errorf("unknown base type=%d", baseType)
+}
+
+func parseFieldString(bytes []byte) string {
+	for i := 0; i < len(bytes); i++ {
+		if bytes[i] == 0x00 {
+			if i > 0 {
+				return string(bytes[:i])
+			}
+			break
+		}
+		if i == len(bytes)-1 {
+			return string(bytes[:i])
+		}
+	}
+	return ""
+}
+
 // unfortunately largely duplicated with parseFitField(). however, in this case, we do not know the type to instantiate
 // into a reflect.Value until we switch on the base type (and the base type in the FieldDescriptionMsg is different),
 // so this is how it is.
 func (d *decoder) parseDevField(dm *defmsg, fieldDescMsg FieldDescriptionMsg, devFieldDesc devDataFieldDesc) (interface{}, error) {
 	dsize := int(devFieldDesc.size)
-	switch fieldDescMsg.FitBaseTypeId {
-	case FitBaseTypeByte, FitBaseTypeEnum, FitBaseTypeUint8, FitBaseTypeUint8z:
-		return uint64(d.tmp[0]), nil
-	case FitBaseTypeSint8:
-		return int64(d.tmp[0]), nil
-	case FitBaseTypeSint16:
-		return int64(dm.arch.Uint16(d.tmp[:dsize])), nil
-	case FitBaseTypeUint16, FitBaseTypeUint16z:
-		return uint64(dm.arch.Uint16(d.tmp[:dsize])), nil
-	case FitBaseTypeSint32:
-		return int64(dm.arch.Uint32(d.tmp[:dsize])), nil
-	case FitBaseTypeUint32, FitBaseTypeUint32z:
-		return uint64(dm.arch.Uint32(d.tmp[:dsize])), nil
-	case FitBaseTypeFloat32:
-		bits := dm.arch.Uint32(d.tmp[:dsize])
-		return float64(math.Float32frombits(bits)), nil
-	case FitBaseTypeFloat64:
-		bits := dm.arch.Uint64(d.tmp[:dsize])
-		return math.Float64frombits(bits), nil
-	case FitBaseTypeString:
-		for j := 0; j < dsize; j++ {
-			if d.tmp[j] == 0x00 {
-				if j > 0 {
-					return string(d.tmp[:j]), nil
-				}
-				break
-			}
-			if j == dsize-1 {
-				return string(d.tmp[:j]), nil
-			}
-		}
+	bsize := types.DecodeBase(byte(fieldDescMsg.FitBaseTypeId)).Size()
+
+	if fieldDescMsg.FitBaseTypeId == FitBaseTypeString || dsize == bsize {
+		return parseFieldData(fieldDescMsg.FitBaseTypeId, d.tmp[:dsize], dm.arch)
 	}
 
-	return nil, fmt.Errorf("unknown base type for dev field description=%v", fieldDescMsg)
+	vals := []interface{}{}
+	for offset := 0; offset+bsize <= dsize; offset += bsize {
+		val, err := parseFieldData(fieldDescMsg.FitBaseTypeId, d.tmp[offset:offset+bsize], dm.arch)
+		if err != nil {
+			return nil, err
+		}
+
+		vals = append(vals, val)
+	}
+
+	return vals, nil
 }
 
 func (d *decoder) parseFitField(dm *defmsg, dfield fieldDef, fieldv reflect.Value) error {

--- a/reader.go
+++ b/reader.go
@@ -825,14 +825,14 @@ func (d *decoder) parseDevField(dm *defmsg, fieldDescMsg FieldDescriptionMsg, de
 	dsize := int(devFieldDesc.size)
 	btype := types.DecodeBase(byte(fieldDescMsg.FitBaseTypeId))
 	bsize := btype.Size()
+	count := dsize / bsize
 
 	val, err := parseFieldData(btype, d.tmp[:dsize], dm.arch)
 	// short circuit if only one value or string
-	if fieldDescMsg.FitBaseTypeId == FitBaseTypeString || dsize == bsize {
+	if fieldDescMsg.FitBaseTypeId == FitBaseTypeString || count == 1 {
 		return val, err
 	}
 
-	count := dsize / bsize
 	vals := reflect.MakeSlice(reflect.SliceOf(val.Type()), count, count)
 	vals.Index(0).Set(val)
 	for i := 1; i < count; i++ {

--- a/reader.go
+++ b/reader.go
@@ -753,7 +753,7 @@ func (d *decoder) parseDataFields(dm *defmsg, knownMsg bool, msgv reflect.Value)
 			BaseTypeId:            fieldDesc.FitBaseTypeId,
 			FieldName:             fieldName,
 			Units:                 units,
-			value:                 value,
+			value:                 reflect.ValueOf(value),
 		}
 		devFieldsMap := msgv.FieldByName("DeveloperFields")
 		devFieldsMap.SetMapIndex(reflect.ValueOf(fieldName), reflect.ValueOf(devField))


### PR DESCRIPTION
Change dev field type to `reflect.Value` and access it using helpers instead of casts. Allows for this to be either a concrete type or an array depending on if there are multiple elements or not.